### PR TITLE
Add app icon metadata for taskbar

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -4,6 +4,11 @@ import "../styles/globals.css";
 export const metadata = {
   title: "Wonnymed",
   description: "Clinical supply with compliance and speed. HQ Hong Kong.",
+  icons: {
+    icon: "/icon.png",
+    shortcut: "/icon.png",
+    apple: "/icon.png",
+  },
 };
 
 export default function RootLayout({ children }) {


### PR DESCRIPTION
## Summary
- reference the existing icon.png in the app metadata so it is used for the taskbar/favicon

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d99d848e648330b7017d6942a24d82