### PR TITLE
Configure next-sitemap to publish sitemap and robots

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,18 @@
+/** @type {import('next-sitemap').IConfig} */
+const siteUrl = process.env.SITE_URL ?? 'https://wonnymed.com';
+
+const EXCLUDED_ROUTES = ['/portal', '/portal/*', '/portal/**'];
+
+module.exports = {
+  siteUrl,
+  generateRobotsTxt: true,
+  exclude: EXCLUDED_ROUTES,
+  robotsTxtOptions: {
+    policies: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "postbuild": "next-sitemap"
   },
   "dependencies": {
     "next": "14.2.3",
@@ -14,6 +15,7 @@
   "devDependencies": {
     "autoprefixer": "10.4.20",
     "postcss": "8.4.45",
-    "tailwindcss": "3.4.9"
+    "tailwindcss": "3.4.9",
+    "next-sitemap": "^4.2.3"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://wonnymed.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://wonnymed.com/</loc>
+    <lastmod>2025-09-29T10:23:57.156Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add a next-sitemap configuration that generates sitemap.xml and robots.txt while excluding private portal routes
- expose the generated sitemap.xml and robots.txt under public/ so they are served by Vercel with an allow-all policy

## Testing
- not run (npm install blocked by 403 from registry)


------
https://chatgpt.com/codex/tasks/task_e_68da5dafa5148330ae47cd450382e54f