### PR TITLE
Improve hero imagery and font loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
-diff --git a//dev/null b/.gitignore
-index 0000000000000000000000000000000000000000..81652838b1838f35f606d83c409f6a4c3954a3be 100644
---- a//dev/null
-+++ b/.gitignore
-@@ -0,0 +1,7 @@
-+node_modules/
-+.next/
-+.DS_Store
-+npm-debug.log*
-+yarn-debug.log*
-+yarn-error.log*
-+.pnp.*
+node_modules/
+.next/
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp.*

--- a/app/layout.js
+++ b/app/layout.js
@@ -146,6 +146,19 @@ export default function RootLayout({ children, params }) {
 
   return (
     <html lang={locale} dir={dir}>
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="preload"
+          as="style"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Noto+Sans+KR:wght@400;700&family=Noto+Sans+SC:wght@400;700&family=Noto+Sans+Arabic:wght@400;700&display=swap"
+        />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Noto+Sans+KR:wght@400;700&family=Noto+Sans+SC:wght@400;700&family=Noto+Sans+Arabic:wght@400;700&display=swap"
+        />
+      </head>
       <body>
         <script
           type="application/ld+json"

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,6 @@
 // === app/page.js (fixed, production-ready) ===
 "use client";
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 
 /**
@@ -716,7 +716,6 @@ const A11Y_LABELS = {
 function BrandStyles() {
   return (
     <style>{`
-      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Noto+Sans+KR:wght@400;700&family=Noto+Sans+SC:wght@400;700&family=Noto+Sans+Arabic:wght@400;700&display=swap');
       :root{
         --wm-primary: #1d4f67;
         --wm-primary-600: #1b4a60;
@@ -729,7 +728,20 @@ function BrandStyles() {
         --wm-surface: #f3f6f8;
         --wm-ink: #0f172a;
       }
-      * { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Noto Sans KR", "Noto Sans SC", "Noto Sans Arabic", sans-serif; }
+      * {
+        font-family:
+          'Inter',
+          system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          Helvetica,
+          Arial,
+          "Noto Sans KR",
+          "Noto Sans SC",
+          "Noto Sans Arabic",
+          sans-serif;
+      }
       body {
         background:
           radial-gradient(120% 120% at 100% 0%, rgba(143, 196, 214, 0.16), transparent 55%),
@@ -774,15 +786,25 @@ function WhatsAppButton({ ariaLabel = "Abrir conversa no WhatsApp", isRTL = fals
 function BrandWordmark({
   label,
   className = "",
-  emblemClassName = "h-9 w-9 text-sm",
+  emblemClassName = "h-9 w-9",
   labelClassName = "font-semibold text-[color:var(--wm-primary-800)] tracking-tight",
+  priority = false,
+  sizes = "(min-width: 768px) 44px, 40px",
 }) {
   return (
     <div className={`flex items-center gap-2 ${className}`}>
       <span
-        className={`inline-flex items-center justify-center rounded-xl bg-gradient-to-br from-[color:var(--wm-primary)] via-[color:var(--wm-primary-600)] to-[color:var(--wm-primary-800)] text-white font-semibold shadow ${emblemClassName}`}
+        className={`inline-flex items-center justify-center overflow-hidden rounded-xl bg-white shadow ${emblemClassName}`}
       >
-        WM
+        <Image
+          src="/assets/logo/w-logo.png"
+          alt={`${label} emblem`}
+          width={128}
+          height={128}
+          priority={priority}
+          className="h-full w-full object-contain"
+          sizes={sizes}
+        />
       </span>
       <span className={labelClassName}>{label}</span>
     </div>
@@ -1095,8 +1117,9 @@ export default function Page() {
                 <BrandWordmark
                   label={t.brand}
                   className="text-base"
-                  emblemClassName="h-11 w-11 text-base"
+                  emblemClassName="h-11 w-11"
                   labelClassName="text-lg font-semibold tracking-tight text-[color:var(--wm-primary-800)]"
+                  priority
                 />
                 {secondaryMetric ? (
                   <div className="mt-4 inline-flex items-center gap-2 rounded-full border border-[color:var(--wm-accent-200)] bg-[color:var(--wm-accent-50)] px-3 py-1 text-xs font-semibold text-[color:var(--wm-primary-700)]">
@@ -1410,7 +1433,7 @@ export default function Page() {
             <BrandWordmark
               label={t.brand}
               labelClassName="font-semibold tracking-tight text-white"
-              emblemClassName="h-10 w-10 text-sm"
+              emblemClassName="h-10 w-10"
             />
             <p className="mt-3 max-w-xs text-white/70">{t.footer.blurb}</p>
           </div>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "NEXT_TELEMETRY_DISABLED=1 next build",
     "start": "next start",
     "postbuild": "next-sitemap"
   },


### PR DESCRIPTION
## Summary
- convert the reusable BrandWordmark to render the stored logo with next/image and prioritize it inside the hero card
- preload the shared Google Fonts stylesheet with font-display swap to reduce LCP delays and remove the legacy @import
- disable Next telemetry during builds and fix the repository .gitignore to keep generated artifacts out of version control

## Testing
- `npm run build` *(fails because the optional postbuild step invokes next-sitemap, which is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da6c6b37fc8330bb7491c81155b770