### PR TITLE
Add localized Open Graph metadata per locale

### DIFF
--- a/app/api/og/[locale]/route.js
+++ b/app/api/og/[locale]/route.js
@@ -1,0 +1,78 @@
+import { ImageResponse } from "next/server";
+
+import { METADATA_BY_LOCALE, resolveLocale } from "../../../lib/metadata";
+
+export const runtime = "edge";
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+const BACKGROUND = "#0E2736";
+const ACCENT = "#5CD2FF";
+const MUTED = "#A7C7D9";
+
+export async function GET(request, { params }) {
+  const locale = resolveLocale(params?.locale);
+  const { ogTitle, description } = METADATA_BY_LOCALE[locale];
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "72px",
+          backgroundColor: BACKGROUND,
+          color: "#F2FAFF",
+          backgroundImage: "radial-gradient(circle at 20% 20%, #15374b, #0e2736)",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+          <div
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 12,
+              textTransform: "uppercase",
+              letterSpacing: 6,
+              fontSize: 26,
+              fontWeight: 600,
+              color: ACCENT,
+            }}
+          >
+            <div style={{ width: 36, height: 4, backgroundColor: ACCENT }} />
+            <span>Wonnymed</span>
+          </div>
+          <div
+            style={{
+              fontSize: 86,
+              lineHeight: 1.05,
+              fontWeight: 700,
+              maxWidth: "90%",
+            }}
+          >
+            {ogTitle}
+          </div>
+        </div>
+        <div
+          style={{
+            fontSize: 32,
+            lineHeight: 1.35,
+            maxWidth: "72%",
+            color: MUTED,
+            fontWeight: 400,
+          }}
+        >
+          {description}
+        </div>
+      </div>
+    ),
+    {
+      width: WIDTH,
+      height: HEIGHT,
+    }
+  );
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,35 +1,14 @@
 // === app/layout.js (refined, full) ===
 import "../styles/globals.css";
 
-const SITE_URL = "https://wonnymed.com";
-const SUPPORTED_LOCALES = ["pt", "en", "es", "zh", "ar", "ko"];
-
-const METADATA_BY_LOCALE = {
-  pt: {
-    title: "Wonnymed | Supply clínico com compliance",
-    description: "Supply clínico com compliance ANVISA/UDI e cotações em 24–48h.",
-  },
-  en: {
-    title: "Wonnymed | Clinical supply with compliance",
-    description: "Clinical supply with ANVISA/UDI diligence and 24–48h quotes.",
-  },
-  es: {
-    title: "Wonnymed | Abastecimiento clínico compliant",
-    description: "Suministro clínico con compliance ANVISA/UDI y cotizaciones en 24–48h.",
-  },
-  zh: {
-    title: "Wonnymed｜合规快速的临床供应",
-    description: "合规的临床供应，ANVISA/UDI 文档齐全，24–48 小时报价。",
-  },
-  ar: {
-    title: "ونيميد | توريد سريري متوافق سريعًا",
-    description: "توريد سريري متوافق مع ANVISA/UDI وعروض خلال ٤٨–٢٤ ساعة.",
-  },
-  ko: {
-    title: "Wonnymed | 컴플라이언스 임상 공급",
-    description: "ANVISA/UDI 컴플라이언스와 24–48시간 견적의 임상 공급.",
-  },
-};
+import {
+  SITE_URL,
+  SUPPORTED_LOCALES,
+  METADATA_BY_LOCALE,
+  buildAlternates,
+  buildCanonical,
+  resolveLocale,
+} from "./lib/metadata";
 
 const ICONS = {
   icon: [
@@ -93,31 +72,14 @@ const STRUCTURED_DATA = {
   ],
 };
 
-function getLocaleFromParams(params) {
-  const maybeLocale = params?.locale;
-  if (typeof maybeLocale === "string" && SUPPORTED_LOCALES.includes(maybeLocale)) {
-    return maybeLocale;
-  }
-  return "pt";
-}
-
-function buildCanonical(locale) {
-  return locale === "pt" ? SITE_URL : `${SITE_URL}/${locale}`;
-}
-
-function buildAlternates() {
-  const languages = SUPPORTED_LOCALES.reduce((acc, locale) => {
-    acc[locale] = buildCanonical(locale);
-    return acc;
-  }, {});
-  languages["x-default"] = SITE_URL;
-  return languages;
-}
-
 export async function generateMetadata({ params }) {
-  const locale = getLocaleFromParams(params);
-  const { title, description } = METADATA_BY_LOCALE[locale];
+  const locale = resolveLocale(params?.locale);
+  const { title, description, ogLocale } = METADATA_BY_LOCALE[locale];
   const canonical = buildCanonical(locale);
+  const alternateLocales = SUPPORTED_LOCALES.filter((current) => current !== locale).map(
+    (current) => METADATA_BY_LOCALE[current].ogLocale
+  );
+  const imageUrl = `${SITE_URL}/api/og/${locale}`;
 
   return {
     title,
@@ -133,7 +95,22 @@ export async function generateMetadata({ params }) {
       url: canonical,
       siteName: "Wonnymed",
       type: "website",
-      locale: locale === "zh" ? "zh-Hans" : locale === "pt" ? "pt-BR" : locale,
+      locale: ogLocale,
+      alternateLocale: alternateLocales,
+      images: [
+        {
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [imageUrl],
     },
     // (Opcional) tema da barra em mobile/Windows
     themeColor: "#29566f",
@@ -141,7 +118,7 @@ export async function generateMetadata({ params }) {
 }
 
 export default function RootLayout({ children, params }) {
-  const locale = getLocaleFromParams(params);
+  const locale = resolveLocale(params?.locale);
   const dir = locale === "ar" ? "rtl" : "ltr";
 
   return (

--- a/app/lib/metadata.js
+++ b/app/lib/metadata.js
@@ -1,0 +1,64 @@
+export const SITE_URL = "https://wonnymed.com";
+
+export const DEFAULT_LOCALE = "pt";
+
+export const SUPPORTED_LOCALES = ["pt", "en", "es", "zh", "ar", "ko"];
+
+export const METADATA_BY_LOCALE = {
+  pt: {
+    title: "Wonnymed | Supply clínico com compliance",
+    description: "Supply clínico com compliance ANVISA/UDI e cotações em 24–48h.",
+    ogLocale: "pt_BR",
+    ogTitle: "Supply clínico com compliance",
+  },
+  en: {
+    title: "Wonnymed | Clinical supply with compliance",
+    description: "Clinical supply with ANVISA/UDI diligence and 24–48h quotes.",
+    ogLocale: "en_US",
+    ogTitle: "Clinical supply with compliance",
+  },
+  es: {
+    title: "Wonnymed | Abastecimiento clínico compliant",
+    description: "Suministro clínico con compliance ANVISA/UDI y cotizaciones en 24–48h.",
+    ogLocale: "es_ES",
+    ogTitle: "Abastecimiento clínico compliant",
+  },
+  zh: {
+    title: "Wonnymed｜合规快速的临床供应",
+    description: "合规的临床供应，ANVISA/UDI 文档齐全，24–48 小时报价。",
+    ogLocale: "zh_CN",
+    ogTitle: "合规快速的临床供应",
+  },
+  ar: {
+    title: "ونيميد | توريد سريري متوافق سريعًا",
+    description: "توريد سريري متوافق مع ANVISA/UDI وعروض خلال ٤٨–٢٤ ساعة.",
+    ogLocale: "ar",
+    ogTitle: "توريد سريري متوافق سريعًا",
+  },
+  ko: {
+    title: "Wonnymed | 컴플라이언스 임상 공급",
+    description: "ANVISA/UDI 컴플라이언스와 24–48시간 견적의 임상 공급.",
+    ogLocale: "ko_KR",
+    ogTitle: "컴플라이언스 임상 공급",
+  },
+};
+
+export function resolveLocale(maybeLocale) {
+  if (typeof maybeLocale === "string" && SUPPORTED_LOCALES.includes(maybeLocale)) {
+    return maybeLocale;
+  }
+  return DEFAULT_LOCALE;
+}
+
+export function buildCanonical(locale) {
+  return locale === DEFAULT_LOCALE ? SITE_URL : `${SITE_URL}/${locale}`;
+}
+
+export function buildAlternates() {
+  const languages = SUPPORTED_LOCALES.reduce((acc, locale) => {
+    acc[locale] = buildCanonical(locale);
+    return acc;
+  }, {});
+  languages["x-default"] = SITE_URL;
+  return languages;
+}


### PR DESCRIPTION
## Summary
- configure the site metadata to serve locale-specific Open Graph and Twitter card details
- generate per-language Open Graph artwork on-demand via an edge API route to avoid bundling binaries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da6f6b7b3483309b56f24ce09ff775