### PR TITLE
Implement validated RFQ form submission

### DIFF
--- a/app/api/rfq/route.js
+++ b/app/api/rfq/route.js
@@ -1,0 +1,270 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const REQUIRED_FIELDS = ["nome", "empresa", "email", "telefone", "linha", "especificacoes"];
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+const LINE_SLUGS = new Set(["hemostatic", "suture", "ppu", "dermato"]);
+const SPAM_PATTERNS = [
+  /https?:\/\//i,
+  /<\/?[a-z][^>]*>/i,
+  /viagra|casino|porn|sex|loan|bitcoin|crypto|forex|escort/i,
+  /\b(?:money\s+back|easy\s+money|investment\s+opportunity)\b/i,
+];
+const MAX_FIELD_LENGTH = 2000;
+
+function sanitizeText(value = "") {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, MAX_FIELD_LENGTH);
+}
+
+function normalizePhone(value = "") {
+  const raw = value.toString();
+  const digits = raw.replace(/[^0-9+]/g, "");
+  if (!digits) return "";
+  if (digits.startsWith("+")) {
+    return `+${digits
+      .slice(1)
+      .replace(/[^0-9]/g, "")
+      .slice(0, 20)}`;
+  }
+  return digits.replace(/[^0-9]/g, "").slice(0, 20);
+}
+
+function deriveLineSlug(label = "", providedSlug = "") {
+  const normalizedProvided = providedSlug.toString().toLowerCase();
+  if (LINE_SLUGS.has(normalizedProvided)) {
+    return normalizedProvided;
+  }
+  const normalized = label.toString().toLowerCase();
+  if (normalized.includes("sutur")) return "suture";
+  if (normalized.includes("ppu") || normalized.includes("drill") || normalized.includes("taladro")) return "ppu";
+  if (normalized.includes("derm")) return "dermato";
+  return "hemostatic";
+}
+
+function detectSpam(payload) {
+  const haystack = [
+    payload.nome,
+    payload.empresa,
+    payload.email,
+    payload.telefone,
+    payload.especificacoes,
+    payload.regulatorio,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  if (SPAM_PATTERNS.some((pattern) => pattern.test(haystack))) {
+    return true;
+  }
+
+  const urlMatches = haystack.match(/https?:\/\//gi);
+  if (urlMatches && urlMatches.length > 0) {
+    return true;
+  }
+
+  const emailsMentioned = haystack.match(/[\w.+-]+@[\w-]+\.[\w.-]+/g);
+  if (emailsMentioned && emailsMentioned.length > 2) {
+    return true;
+  }
+
+  return false;
+}
+
+async function verifyRecaptcha(token, action, ip) {
+  const secret = process.env.RECAPTCHA_SECRET_KEY;
+  if (!secret) {
+    return { success: true, score: 1, skipped: true };
+  }
+
+  if (!token) {
+    return { success: false, score: 0, error: "missing-token" };
+  }
+
+  const params = new URLSearchParams();
+  params.append("secret", secret);
+  params.append("response", token);
+  if (ip) {
+    params.append("remoteip", ip);
+  }
+
+  const response = await fetch("https://www.google.com/recaptcha/api/siteverify", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: params,
+  });
+
+  const data = await response.json();
+  if (!data.success) {
+    return { success: false, score: data.score ?? 0, error: "verification-failed" };
+  }
+
+  if (action && data.action && action !== data.action) {
+    return { success: false, score: data.score ?? 0, error: "action-mismatch" };
+  }
+
+  if (typeof data.score === "number" && data.score < 0.5) {
+    return { success: false, score: data.score, error: "low-score" };
+  }
+
+  return { success: true, score: data.score ?? 0.9 };
+}
+
+function buildEmailText(payload) {
+  const lines = [
+    `Idioma: ${payload.lang || ""}`,
+    `Linha selecionada: ${payload.linha || ""} (${payload.linhaSlug})`,
+    `Nome: ${payload.nome}`,
+    `Empresa: ${payload.empresa}`,
+    `Tipo de conta: ${payload.tipoConta || ""}`,
+    `E-mail: ${payload.email}`,
+    `Telefone: ${payload.telefone}`,
+    `Quantidade: ${payload.quantidade || ""}`,
+    `Frequência: ${payload.frequencia || ""}`,
+    `Prazo desejado: ${payload.prazo || ""}`,
+    `Local de entrega: ${payload.entrega || ""}`,
+    `Requisitos regulatórios: ${payload.regulatorio || ""}`,
+    "",
+    "Especificações técnicas:",
+    payload.especificacoes || "",
+  ];
+
+  return lines.join("\n");
+}
+
+async function sendEmail(payload) {
+  const apiKey = process.env.RESEND_API_KEY;
+  const toEmail = process.env.RFQ_TO_EMAIL || "contato@wonnymed.com";
+  const fromEmail = process.env.RFQ_FROM_EMAIL || "rfq@wonnymed.com";
+
+  if (!apiKey) {
+    console.warn("RESEND_API_KEY not configured. Skipping email dispatch.");
+    return { skipped: true };
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: fromEmail,
+      to: [toEmail],
+      subject: `[RFQ] ${payload.empresa} — ${payload.linhaSlug}`,
+      text: buildEmailText(payload),
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Email dispatch failed: ${errorText}`);
+  }
+
+  return response.json();
+}
+
+async function persistLead(payload) {
+  const webhook = process.env.RFQ_CRM_WEBHOOK;
+  if (!webhook) {
+    return { skipped: true };
+  }
+
+  try {
+    await fetch(webhook, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        source: "rfq-form",
+        receivedAt: new Date().toISOString(),
+        payload,
+      }),
+    });
+    return { success: true };
+  } catch (error) {
+    console.error("Failed to persist lead", error);
+    return { success: false };
+  }
+}
+
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+  }
+
+  const cleaned = {};
+  for (const key of Object.keys(body)) {
+    const value = body[key];
+    cleaned[key] = typeof value === "string" ? sanitizeText(value) : value;
+  }
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!cleaned[field] || !String(cleaned[field]).trim()) {
+      return NextResponse.json({ error: `Campo obrigatório ausente: ${field}` }, { status: 400 });
+    }
+  }
+
+  const email = sanitizeText(cleaned.email).toLowerCase();
+  if (!EMAIL_REGEX.test(email)) {
+    return NextResponse.json({ error: "E-mail inválido" }, { status: 400 });
+  }
+
+  const phoneDigits = cleaned.telefone.replace(/\D/g, "");
+  if (phoneDigits.length < 8) {
+    return NextResponse.json({ error: "Telefone inválido" }, { status: 400 });
+  }
+
+  if (sanitizeText(cleaned.especificacoes).length < 10) {
+    return NextResponse.json({ error: "Especificações insuficientes" }, { status: 400 });
+  }
+
+  const linhaSlug = deriveLineSlug(cleaned.linha, cleaned.linhaSlug);
+  if (!LINE_SLUGS.has(linhaSlug)) {
+    return NextResponse.json({ error: "Linha inválida" }, { status: 400 });
+  }
+
+  const spam = detectSpam(cleaned);
+  if (spam) {
+    return NextResponse.json({ error: "Submission rejected" }, { status: 422 });
+  }
+
+  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "";
+  const recaptcha = await verifyRecaptcha(cleaned.recaptchaToken, cleaned.recaptchaAction, ip);
+  if (!recaptcha.success) {
+    return NextResponse.json({ error: "Recaptcha inválido" }, { status: 400 });
+  }
+
+  const payload = {
+    ...cleaned,
+    email,
+    linhaSlug,
+    telefone: normalizePhone(cleaned.telefone),
+  };
+
+  try {
+    await sendEmail(payload);
+  } catch (error) {
+    console.error("RFQ email error", error);
+    return NextResponse.json({ error: "Falha ao enviar e-mail" }, { status: 500 });
+  }
+
+  await persistLead({
+    nome: payload.nome,
+    empresa: payload.empresa,
+    email: payload.email,
+    telefone: payload.telefone,
+    linhaSlug: payload.linhaSlug,
+    lang: payload.lang,
+    createdAt: new Date().toISOString(),
+  });
+
+  return NextResponse.json({ message: "RFQ recebido com sucesso." });
+}

--- a/app/page.js
+++ b/app/page.js
@@ -2,12 +2,16 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
+import Script from "next/script";
 
 /**
  * IMPORTANT:
  * - Do NOT import global CSS here. In the App Router, globals must be imported in app/layout.js.
  * - This file is self-contained and safe to drop into `app/page.js`.
  */
+
+const RECAPTCHA_SITE_KEY = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || "";
+const RECAPTCHA_ACTION = "rfq_submit";
 
 // ----- Locales ---------------------------------------------------------------
 const LOCALES = [
@@ -119,7 +123,7 @@ const I18N = {
       accountType: "Tipo de conta",
       types: ["Hospital privado", "Hospital público", "Distribuidor"],
       email: "E-mail*",
-      phone: "Telefone",
+      phone: "Telefone*",
       line: "Linha*",
       lines: ["Hemostáticos", "Suturas", "Drills PPU", "Dermato Pro (Beauty)"],
       specs: "Especificações técnicas / marcas equivalentes*",
@@ -133,6 +137,7 @@ const I18N = {
       regPH: "Ex.: classe II/III, docs obrigatórios, validade mínima...",
       submit: "Enviar RFQ",
       legal: "Ao enviar, você concorda com nossos Termos e confirma que não está compartilhando PHI.",
+      errorRequired: "Preencha os campos obrigatórios e revise os dados destacados.",
       okTitle: "Recebido com sucesso",
       okMsg: "Retornaremos em 24–48h com comparativo e proposta.",
       backTop: "Voltar ao topo",
@@ -228,7 +233,7 @@ const I18N = {
       accountType: "Account type",
       types: ["Private hospital", "Public hospital", "Distributor"],
       email: "Email*",
-      phone: "Phone",
+      phone: "Phone*",
       line: "Line*",
       lines: ["Hemostatics", "Sutures", "Drills PPU", "Derma Pro (Beauty)"],
       specs: "Technical specs / equivalent brands*",
@@ -241,6 +246,7 @@ const I18N = {
       regPH: "E.g.: class II/III, mandatory docs, shelf-life requirements...",
       submit: "Submit RFQ",
       legal: "By submitting you agree to our Terms and confirm you’re not sharing PHI.",
+      errorRequired: "Please fill in the required fields and review the highlighted information.",
       okTitle: "Received successfully",
       okMsg: "We’ll reply in 24–48h with the comparison and proposal.",
       backTop: "Back to top",
@@ -338,7 +344,7 @@ const I18N = {
       accountType: "Tipo de cuenta",
       types: ["Hospital privado", "Hospital público", "Distribuidor"],
       email: "Email*",
-      phone: "Teléfono",
+      phone: "Teléfono*",
       line: "Línea*",
       lines: ["Hemostáticos", "Suturas", "Taladros PPU", "Derma Pro (Beauty)"],
       specs: "Especificaciones técnicas / marcas equivalentes*",
@@ -351,6 +357,7 @@ const I18N = {
       regPH: "Ej.: II/III, documentos obligatorios, vida útil mínima...",
       submit: "Enviar RFQ",
       legal: "Al enviar acepta nuestros Términos y confirma que no comparte PHI.",
+      errorRequired: "Complete los campos obligatorios y revise la información resaltada.",
       okTitle: "Recibido correctamente",
       okMsg: "Responderemos en 24–48h con la comparación y la propuesta.",
       backTop: "Volver arriba",
@@ -445,7 +452,7 @@ const I18N = {
       accountType: "账户类型",
       types: ["民营医院", "公立医院", "经销商"],
       email: "邮箱*",
-      phone: "电话",
+      phone: "电话*",
       line: "产品线*",
       lines: ["止血材料", "缝合线", "按次付费钻机", "专业皮肤科"],
       specs: "技术规格 / 同类品牌*",
@@ -458,6 +465,7 @@ const I18N = {
       regPH: "如：II/III 类、必备文件、效期要求等",
       submit: "提交 RFQ",
       legal: "提交即同意条款并确认不包含患者隐私信息。",
+      errorRequired: "请填写必填字段并核对高亮信息。",
       okTitle: "已收到",
       okMsg: "我们将在 24–48 小时内回复。",
       backTop: "返回顶部",
@@ -546,7 +554,7 @@ const I18N = {
       accountType: "نوع الحساب",
       types: ["مستشفى خاص", "مستشفى حكومي", "موزّع"],
       email: "البريد*",
-      phone: "الهاتف",
+      phone: "الهاتف*",
       line: "الخط*",
       lines: ["مواد إرقاء", "خيوط", "مثاقب بالدفع", "جلدية مهنية"],
       specs: "مواصفات تقنية / علامات مكافئة*",
@@ -559,6 +567,7 @@ const I18N = {
       regPH: "مثال: II/III، وثائق إلزامية، صلاحية…",
       submit: "إرسال RFQ",
       legal: "تؤكد عدم تضمين بيانات مرضى.",
+      errorRequired: "يرجى تعبئة الحقول المطلوبة ومراجعة البيانات المظللة.",
       okTitle: "تم الاستلام",
       okMsg: "نرد خلال 24–48 ساعة.",
       backTop: "العودة للأعلى",
@@ -652,7 +661,7 @@ const I18N = {
       accountType: "계정 유형",
       types: ["민영 병원", "공공 병원", "유통사"],
       email: "이메일*",
-      phone: "전화",
+      phone: "전화*",
       line: "라인*",
       lines: ["지혈재", "봉합사", "드릴 PPU", "더마 프로"],
       specs: "기술 사양 / 동등 브랜드*",
@@ -665,6 +674,7 @@ const I18N = {
       regPH: "예: II/III, 필수 문서, 유효기간",
       submit: "RFQ 제출",
       legal: "환자정보 미포함 확인.",
+      errorRequired: "필수 항목을 입력하고 강조된 정보를 확인해주세요.",
       okTitle: "접수 완료",
       okMsg: "24–48시간 내 회신.",
       backTop: "맨 위로",
@@ -836,7 +846,7 @@ function Field({ label, name, type = "text", value, onChange, placeholder }) {
     <label className="block">
       <span className="text-sm font-medium text-neutral-700">{label}</span>
       <input
-        className="mt-1 w-full rounded-2xl border border-white/60 bg-white/80 px-3 py-2.5 text-sm shadow-sm outline-none focus:border-[color:var(--wm-primary-700)] focus:ring-2 focus:ring-[color:var(--wm-accent-200)]"
+        className="mt-1 w-full rounded-2xl border border-[color:var(--wm-accent-200)] bg-white/95 px-3 py-2.5 text-sm shadow-sm outline-none focus:border-[color:var(--wm-primary-700)] focus:ring-2 focus:ring-[color:var(--wm-accent-200)]"
         name={name}
         type={type}
         value={value}
@@ -851,7 +861,7 @@ function Select({ label, name, value, onChange, opts = [] }) {
     <label className="block">
       <span className="text-sm font-medium text-neutral-700">{label}</span>
       <select
-        className="mt-1 w-full rounded-2xl border border-white/60 bg-white/80 px-3 py-2.5 text-sm shadow-sm outline-none focus:border-[color:var(--wm-primary-700)] focus:ring-2 focus:ring-[color:var(--wm-accent-200)]"
+        className="mt-1 w-full rounded-2xl border border-[color:var(--wm-accent-200)] bg-white/95 px-3 py-2.5 text-sm shadow-sm outline-none focus:border-[color:var(--wm-primary-700)] focus:ring-2 focus:ring-[color:var(--wm-accent-200)]"
         name={name}
         value={value}
         onChange={onChange}
@@ -870,7 +880,7 @@ function Area({ label, name, value, onChange, placeholder }) {
     <label className="block mt-4">
       <span className="text-sm font-medium text-neutral-700">{label}</span>
       <textarea
-        className="mt-1 min-h-[110px] w-full rounded-2xl border border-white/60 bg-white/80 px-3 py-2.5 text-sm shadow-sm outline-none focus:border-[color:var(--wm-primary-700)] focus:ring-2 focus:ring-[color:var(--wm-accent-200)]"
+        className="mt-1 min-h-[110px] w-full rounded-2xl border border-[color:var(--wm-accent-200)] bg-white/95 px-3 py-2.5 text-sm shadow-sm outline-none focus:border-[color:var(--wm-primary-700)] focus:ring-2 focus:ring-[color:var(--wm-accent-200)]"
         name={name}
         value={value}
         onChange={onChange}
@@ -878,6 +888,24 @@ function Area({ label, name, value, onChange, placeholder }) {
       />
     </label>
   );
+}
+
+function deriveLineSlug(value = "") {
+  const normalized = value.toString().toLowerCase();
+  if (normalized.includes("sutur")) return "suture";
+  if (normalized.includes("ppu") || normalized.includes("drill")) return "ppu";
+  if (normalized.includes("derm")) return "dermato";
+  return "hemostatic";
+}
+
+function normalizePhone(value = "") {
+  const raw = value.toString();
+  const digits = raw.replace(/[^0-9+]/g, "");
+  if (!digits) return "";
+  if (digits.startsWith("+")) {
+    return `+${digits.slice(1).replace(/[^0-9]/g, "").slice(0, 20)}`;
+  }
+  return digits.replace(/[^0-9]/g, "").slice(0, 20);
 }
 
 // ----- Page ------------------------------------------------------------------
@@ -891,32 +919,33 @@ export default function Page() {
 
   const [sent, setSent] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [form, setForm] = useState({
-    nome: "",
-    empresa: "",
-    tipoConta: t.form?.types?.[0] ?? "",
-    email: "",
-    telefone: "",
-    linha: t.form?.lines?.[0] ?? "",
-    especificacoes: "",
-    quantidade: "",
-    frequencia: "",
-    prazo: "",
-    entrega: "",
-    regulatorio: "",
-  });
+  const [errorMsg, setErrorMsg] = useState("");
+  const initialForm = useMemo(
+    () => ({
+      nome: "",
+      empresa: "",
+      tipoConta: t.form?.types?.[0] ?? "",
+      email: "",
+      telefone: "",
+      linha: t.form?.lines?.[0] ?? "",
+      especificacoes: "",
+      quantidade: "",
+      frequencia: "",
+      prazo: "",
+      entrega: "",
+      regulatorio: "",
+    }),
+    [t.form?.lines, t.form?.types]
+  );
+  const [form, setForm] = useState(() => initialForm);
 
   useEffect(() => {
     // When language changes, reset defaults for selects and clear sent/loading
     setLoading(false);
     setSent(false);
-    setForm((prev) => ({
-      ...prev,
-      tipoConta: t.form?.types?.[0] ?? "",
-      linha: t.form?.lines?.[0] ?? "",
-    }));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lang]);
+    setErrorMsg("");
+    setForm(initialForm);
+  }, [initialForm, lang]);
 
   const fallback = I18N.en;
   const nav = { ...fallback.nav, ...(t.nav || {}) };
@@ -937,30 +966,131 @@ export default function Page() {
   const heroMetrics = ((t.metrics?.length ? t.metrics : fallback.metrics) || []).slice(0, 2);
   const [primaryMetric, secondaryMetric] = heroMetrics;
 
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+
   function handleChange(e) {
     const { name, value } = e.target;
+    setErrorMsg("");
     setForm((f) => ({ ...f, [name]: value }));
   }
+
   function validate() {
-    const req = ["nome", "empresa", "email", "linha", "especificacoes"];
-    return req.every((k) => String(form[k] || "").trim().length > 1);
+    const issues = [];
+    const required = {
+      nome: form.nome,
+      empresa: form.empresa,
+      email: form.email,
+      telefone: form.telefone,
+      linha: form.linha,
+      especificacoes: form.especificacoes,
+    };
+
+    Object.entries(required).forEach(([key, value]) => {
+      if (!String(value || "").trim()) {
+        issues.push(key);
+      }
+    });
+
+    if (required.email && !emailRegex.test(String(required.email).trim())) {
+      issues.push("email_invalido");
+    }
+
+    const phoneDigits = String(required.telefone || "").replace(/\D/g, "");
+    if (phoneDigits.length < 8) {
+      issues.push("telefone_curto");
+    }
+
+    if (String(required.especificacoes || "").trim().length < 10) {
+      issues.push("especificacoes_curta");
+    }
+
+    if (!required.linha) {
+      issues.push("linha_invalida");
+    }
+
+    return issues;
   }
-  function handleSubmit(e) {
+
+  async function handleSubmit(e) {
     e.preventDefault();
-    if (!validate()) {
-      alert("Please fill required fields / Preencha os campos obrigatórios.");
+    const issues = validate();
+    if (issues.length) {
+      setErrorMsg(t.form?.errorRequired ?? "Please review the required fields.");
       return;
     }
+
     setLoading(true);
-    setTimeout(() => {
-      setLoading(false);
+    setErrorMsg("");
+
+    const recaptchaToken = await new Promise((resolve) => {
+      if (!RECAPTCHA_SITE_KEY || typeof window === "undefined" || !window.grecaptcha) {
+        resolve(null);
+        return;
+      }
+
+      try {
+        window.grecaptcha.ready(() => {
+          window.grecaptcha
+            .execute(RECAPTCHA_SITE_KEY, { action: RECAPTCHA_ACTION })
+            .then(resolve)
+            .catch(() => resolve(null));
+        });
+      } catch (err) {
+        resolve(null);
+      }
+    });
+
+    const payload = {
+      ...form,
+      telefone: normalizePhone(form.telefone),
+      lang,
+      linhaSlug: deriveLineSlug(form.linha),
+      recaptchaToken,
+      recaptchaAction: RECAPTCHA_ACTION,
+    };
+
+    const selectedLine = form.linha;
+
+    try {
+      const response = await fetch("/api/rfq", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        throw new Error(data?.error || "Unable to submit RFQ.");
+      }
+
       setSent(true);
-    }, 800);
+      setForm(initialForm);
+
+      if (typeof window !== "undefined" && typeof window.gtag === "function") {
+        window.gtag("event", "rfq_submit", {
+          language: lang,
+          line: deriveLineSlug(selectedLine),
+        });
+      }
+    } catch (err) {
+      console.error(err);
+      setErrorMsg(err.message || "Unable to submit RFQ.");
+      setSent(false);
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (
     <div dir={dir} className="min-h-screen text-neutral-900">
       <BrandStyles />
+      {RECAPTCHA_SITE_KEY ? (
+        <Script src={`https://www.google.com/recaptcha/api.js?render=${RECAPTCHA_SITE_KEY}`} strategy="lazyOnload" />
+      ) : null}
 
       {topBarMessage ? (
         <div className="hidden md:block bg-[color:var(--wm-primary-800)] text-white">
@@ -1365,7 +1495,10 @@ export default function Page() {
             </p>
           </div>
 
-          <form onSubmit={handleSubmit} className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-lg backdrop-blur">
+          <form
+            onSubmit={handleSubmit}
+            className="rounded-3xl border border-[color:var(--wm-accent-200)] bg-gradient-to-br from-white/95 via-[color:var(--wm-accent-50)] to-white p-6 shadow-xl shadow-[rgba(16,47,61,0.12)] backdrop-blur"
+          >
             {sent ? (
               <div className="text-center">
                 <h3 className="text-lg font-semibold">{t.form.okTitle}</h3>
@@ -1376,6 +1509,11 @@ export default function Page() {
               </div>
             ) : (
               <>
+                {errorMsg ? (
+                  <p className="mb-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                    {errorMsg}
+                  </p>
+                ) : null}
                 <Field label={t.form.name} name="nome" value={form.nome} onChange={handleChange} />
                 <Field label={t.form.company} name="empresa" value={form.empresa} onChange={handleChange} />
                 <Select label={t.form.accountType} name="tipoConta" value={form.tipoConta} onChange={handleChange} opts={t.form.types} />


### PR DESCRIPTION
## Summary
- add client-side RFQ validation, reCAPTCHA execution, and GA4 tracking on submit
- surface localized error messaging and require phone details in all locales
- implement /api/rfq route with server-side validation, reCAPTCHA verification, spam filtering, email dispatch, and CRM webhook stub
- refresh the RFQ form background styling with an accent gradient that aligns with the existing palette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da74013160833089eba575bcafe3fe