### PR TITLE
Enable smooth anchor navigation with active states

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,4 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-html, body { min-height: 100%; }
+html, body {
+  min-height: 100%;
+  scroll-behavior: smooth;
+}


### PR DESCRIPTION
## Summary
- add a scrollspy effect to the main navigation so active sections match the URL hash
- rename the solutions and how sections to use the new anchor ids and update internal links
- enable smooth scrolling for anchor navigation across the site

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7e1375cc83308bc6fe5f018f7e9a