### PR TITLE
Persist locale across navigation

### DIFF
--- a/app/compliance/page.js
+++ b/app/compliance/page.js
@@ -1,4 +1,8 @@
+import { cookies } from "next/headers";
+
 import ComplianceContent from "./ComplianceContent";
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from "../lib/metadata";
+import { LOCALE_COOKIE } from "../lib/locale";
 
 export const metadata = {
   title: "Compliance regulatório | Wonnymed",
@@ -6,13 +10,16 @@ export const metadata = {
     "Como validamos ANVISA, UDI, ISO 13485 e IFU/MSDS antes de cada cotação para garantir rastreabilidade clínica.",
 };
 
-const SUPPORTED_LANGUAGES = ["pt", "en", "es", "zh", "ar", "ko"];
-const DEFAULT_LANG = "pt";
-
 export default function CompliancePage({ searchParams }) {
   const requested = typeof searchParams?.lang === "string" ? searchParams.lang.toLowerCase() : "";
-  const isSupported = SUPPORTED_LANGUAGES.includes(requested);
-  const initialLang = isSupported ? requested : DEFAULT_LANG;
+  const hasQueryLocale = SUPPORTED_LOCALES.includes(requested);
 
-  return <ComplianceContent initialLang={initialLang} fromQuery={isSupported} />;
+  const localeCookie = cookies().get(LOCALE_COOKIE)?.value ?? "";
+  const cookieLocale = localeCookie.toLowerCase();
+  const hasCookieLocale = SUPPORTED_LOCALES.includes(cookieLocale);
+
+  const fallbackLocale = hasCookieLocale ? cookieLocale : DEFAULT_LOCALE;
+  const initialLang = hasQueryLocale ? requested : fallbackLocale;
+
+  return <ComplianceContent initialLang={initialLang} />;
 }

--- a/app/lib/locale.js
+++ b/app/lib/locale.js
@@ -1,0 +1,5 @@
+export const LOCALE_COOKIE = "wm_locale";
+export const LOCALE_QUERY_PARAM = "lang";
+export const RTL_LOCALES = ["ar"];
+
+export const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365; // 1 year

--- a/app/lib/useLocaleSync.js
+++ b/app/lib/useLocaleSync.js
@@ -1,0 +1,204 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { COOKIE_MAX_AGE_SECONDS, RTL_LOCALES } from "./locale";
+
+function escapeForRegex(value = "") {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function readCookieValue(name) {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const pattern = new RegExp(`(?:^|; )${escapeForRegex(name)}=([^;]*)`);
+  const match = document.cookie.match(pattern);
+
+  if (!match || match.length < 2) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+export function useLocaleSync({
+  supportedLocales,
+  defaultLocale,
+  cookieName,
+  initialLocale,
+  rtlLocales = RTL_LOCALES,
+  queryParam = "lang",
+}) {
+  const supportedSet = useMemo(() => {
+    return new Set((supportedLocales || []).map((code) => code.toLowerCase()));
+  }, [supportedLocales]);
+
+  const rtlSet = useMemo(() => {
+    return new Set((rtlLocales || []).map((code) => code.toLowerCase()));
+  }, [rtlLocales]);
+
+  const initialNormalized = useMemo(() => {
+    if (typeof initialLocale === "string") {
+      const candidate = initialLocale.toLowerCase();
+      if (supportedSet.has(candidate)) {
+        return candidate;
+      }
+    }
+    return defaultLocale;
+  }, [defaultLocale, initialLocale, supportedSet]);
+
+  const [locale, setLocaleState] = useState(initialNormalized);
+  const userNavigationRef = useRef(false);
+
+  const normalize = useCallback(
+    (value) => {
+      if (typeof value === "string") {
+        const lowered = value.toLowerCase();
+        if (supportedSet.has(lowered)) {
+          return lowered;
+        }
+      }
+      return defaultLocale;
+    },
+    [defaultLocale, supportedSet]
+  );
+
+  const readLocaleFromUrl = useCallback(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    try {
+      const url = new URL(window.location.href);
+      const param = url.searchParams.get(queryParam);
+      if (typeof param === "string") {
+        const lowered = param.toLowerCase();
+        if (supportedSet.has(lowered)) {
+          return lowered;
+        }
+      }
+    } catch {
+      // Ignore URL parsing errors
+    }
+
+    return null;
+  }, [queryParam, supportedSet]);
+
+  const setLocaleInternal = useCallback(
+    (nextLocale, userInitiated) => {
+      setLocaleState((current) => {
+        const normalized = normalize(nextLocale);
+        if (current === normalized) {
+          userNavigationRef.current = false;
+          return current;
+        }
+        userNavigationRef.current = Boolean(userInitiated);
+        return normalized;
+      });
+    },
+    [normalize]
+  );
+
+  const selectLocale = useCallback(
+    (nextLocale) => {
+      setLocaleInternal(nextLocale, true);
+    },
+    [setLocaleInternal]
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const fromUrl = readLocaleFromUrl();
+    if (fromUrl) {
+      setLocaleInternal(fromUrl, false);
+      return;
+    }
+
+    const fromCookie = readCookieValue(cookieName);
+    if (fromCookie) {
+      setLocaleInternal(fromCookie, false);
+      return;
+    }
+
+    setLocaleInternal(defaultLocale, false);
+  }, [cookieName, defaultLocale, readLocaleFromUrl, setLocaleInternal]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const handlePopState = () => {
+      const fromUrl = readLocaleFromUrl();
+      if (fromUrl) {
+        setLocaleInternal(fromUrl, false);
+      } else {
+        setLocaleInternal(defaultLocale, false);
+      }
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [defaultLocale, readLocaleFromUrl, setLocaleInternal]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    document.documentElement.lang = locale;
+    document.documentElement.dir = rtlSet.has(locale) ? "rtl" : "ltr";
+  }, [locale, rtlSet]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    document.cookie = `${cookieName}=${encodeURIComponent(locale)};path=/;max-age=${COOKIE_MAX_AGE_SECONDS};SameSite=Lax`;
+  }, [cookieName, locale]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const url = new URL(window.location.href);
+      if (locale === defaultLocale) {
+        url.searchParams.delete(queryParam);
+      } else {
+        url.searchParams.set(queryParam, locale);
+      }
+
+      const nextUrl = url.toString();
+      if (nextUrl === window.location.href) {
+        userNavigationRef.current = false;
+        return;
+      }
+
+      const method = userNavigationRef.current ? "pushState" : "replaceState";
+      window.history[method]({}, "", nextUrl);
+      userNavigationRef.current = false;
+    } catch {
+      // Ignore URL update issues
+    }
+  }, [defaultLocale, locale, queryParam]);
+
+  return {
+    locale,
+    selectLocale,
+    setLocale: (nextLocale) => setLocaleInternal(nextLocale, false),
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared locale synchronization hook that keeps the language in the URL query string and a long-lived cookie
- update the home page selector to use the new hook, scroll to the top on manual changes, and preserve the active route
- update the compliance page to honour the persisted locale on the server and client while using the shared hook

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daa4b6155c833097e265f64c40430e