### PR TITLE
Persist locale across compliance page language changes

### DIFF
--- a/app/compliance/ComplianceContent.jsx
+++ b/app/compliance/ComplianceContent.jsx
@@ -534,6 +534,10 @@ export default function ComplianceContent({ initialLang }) {
 
   const t = useMemo(() => COPY[lang] || COPY[FALLBACK_LANG], [lang]);
   const isRTL = lang === "ar";
+  const homeHref = useMemo(() => {
+    const params = new URLSearchParams({ [LOCALE_QUERY_PARAM]: lang });
+    return `/?${params.toString()}`;
+  }, [lang]);
 
   return (
     <div dir={isRTL ? "rtl" : "ltr"} lang={lang} className="bg-white text-neutral-900">
@@ -658,7 +662,7 @@ export default function ComplianceContent({ initialLang }) {
               <h3 className="text-lg font-semibold text-neutral-900">{t.nextStepsTitle}</h3>
               <p className="mt-2">{t.nextStepsDescription}</p>
               <a
-                href="/"
+                href={homeHref}
                 className="mt-4 inline-flex items-center justify-center gap-2 rounded-full bg-[color:var(--wm-primary)] px-6 py-3 font-semibold text-white shadow-md transition hover:bg-[color:var(--wm-primary-700)] hover:shadow-lg"
               >
                 {t.backCta}

--- a/app/compliance/page.js
+++ b/app/compliance/page.js
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 
 import ComplianceContent from "./ComplianceContent";
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from "../lib/metadata";
-import { LOCALE_COOKIE } from "../lib/locale";
+import { LOCALE_COOKIE, LOCALE_QUERY_PARAM } from "../lib/locale";
 
 export const metadata = {
   title: "Compliance regulatório | Wonnymed",
@@ -11,10 +11,12 @@ export const metadata = {
 };
 
 export default function CompliancePage({ searchParams }) {
-  const requested = typeof searchParams?.lang === "string" ? searchParams.lang.toLowerCase() : "";
+  const requestedParam = searchParams?.[LOCALE_QUERY_PARAM];
+  const requested = typeof requestedParam === "string" ? requestedParam.toLowerCase() : "";
   const hasQueryLocale = SUPPORTED_LOCALES.includes(requested);
 
-  const localeCookie = cookies().get(LOCALE_COOKIE)?.value ?? "";
+  const cookieStore = cookies();
+  const localeCookie = cookieStore.get(LOCALE_COOKIE)?.value ?? "";
   const cookieLocale = localeCookie.toLowerCase();
   const hasCookieLocale = SUPPORTED_LOCALES.includes(cookieLocale);
 

--- a/app/page.js
+++ b/app/page.js
@@ -1166,10 +1166,10 @@ function LocalizedHome({ lang, onLangChange }) {
   const complianceNote = t.verifiedNote ?? fallback.verifiedNote;
   const inlineArrow = isRTL ? "←" : "→";
   const diagonalArrow = isRTL ? "↖" : "↗";
-  const complianceHref = useMemo(
-    () => (lang === "pt" ? "/compliance" : `/compliance?lang=${lang}`),
-    [lang]
-  );
+  const complianceHref = useMemo(() => {
+    const params = new URLSearchParams({ [LOCALE_QUERY_PARAM]: lang });
+    return `/compliance?${params.toString()}`;
+  }, [lang]);
 
   const navLinks = useMemo(
     () => [


### PR DESCRIPTION
## Summary
- update the locale synchronization hook to drive URL updates through the Next.js router and always reflect the active ?lang parameter
- persist the resolved locale cookie on the compliance page and keep navigation links (home/compliance) scoped to the current language

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab203faf88330a5624ffd128c8bb4